### PR TITLE
Updates 04/08

### DIFF
--- a/heatmap.html
+++ b/heatmap.html
@@ -97,6 +97,21 @@
         border-radius: 4px;
         /* Roundness of the thumb */
       }
+
+      .quotation-list {
+        position: fixed;
+        z-index: 1000;
+        background-color: #f9f9f9;
+        border: 1px solid #ccc;
+        padding: 10px;
+        box-shadow: 3px 3px 5px #888888;
+      }
+
+      .quotation-list li {
+        color: blue;
+        cursor: pointer;
+        text-decoration: underline;
+      }
     </style>
   </head>
 

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
   fetchAndLoadData("key_and_data/highlighted_ls_text.html", lsCorpusContainer);
   fetchAndLoadData("key_and_data/highlighted_t_text.html", tTextContainer);
 
+  let list;
   let tip;
 
   // Tooltip functionality
@@ -45,8 +46,44 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
 
+const scrollToUidInT = (uid) => {
+  // Find the corresponding T Text citation using data-uid attribute
+  const tTextCitation = tTextContainer.querySelector(`[data-uid*="${uid}"]`);
+  // Scroll to the T Text citation if found
+  if (tTextCitation) {
+    tTextCitation.scrollIntoView({ behavior: "smooth", block: "start" });
+  } else {
+    console.log("No corresponding T Text citation found for UID: " + uid);
+  }
+}
+
+const createQuotationList = (event) => {
+  event.stopPropagation();  // prevents the event from "bubbling" up to the document.click handler defined below
+  const el = event.target;
+  const uids = el.dataset.uid.split(",");
+  list = document.createElement("ul");
+  list.classList.add("quotation-list");
+  list.style.left = `${event.clientX}px`;
+  list.style.top = `${event.clientY}px`;
+  uids.forEach((uid) => {
+    const listItem = document.createElement("li");
+    listItem.textContent = `-> ${uid}`;
+    listItem.addEventListener("click", () => scrollToUidInT(uid));
+    list.appendChild(listItem);
+  })
+  el.appendChild(list);
+}
+
+const clearQuotationList = () => {
+  if (list) {
+    list.remove();
+    list = null;
+  }
+}
+
   // Click-Scroll functionality for LS Corpus
 lsCorpusContainer.addEventListener("click", function (event) {
+  clearQuotationList();  
   const clickedElement = event.target;
   if (clickedElement.classList.contains("highlight")) {
     const uid = clickedElement.getAttribute("data-uid");
@@ -58,15 +95,14 @@ lsCorpusContainer.addEventListener("click", function (event) {
       const matchType = clickedElement.getAttribute("data-match-type");
       if (matchType === "1") {
         console.log("data-match-type = 1");
-        // Find the corresponding T Text citation using data-uid attribute
-        const tTextCitation = tTextContainer.querySelector(`[data-uid*="${uid}"]`);
-        // Scroll to the T Text citation if found
-        if (tTextCitation) {
-          tTextCitation.scrollIntoView({ behavior: "smooth", block: "start" });
+        if (uid.includes(",")) {
+          // Multiple UIDs -- show a menu
+          createQuotationList(event);
         } else {
-          console.log("No corresponding T Text citation found for UID: " + uid);
+          // Single UID -- scroll directly to corresponding element in T
+          scrollToUidInT(uid);
         }
-      } else if (matchType === "0") {
+      } else if (matchType === "0") { 
         console.log("data-match-type = 0");
         console.log("No corresponding T Text citation found for UID: " + uid);
       } else if (matchType === "2") {
@@ -78,6 +114,9 @@ lsCorpusContainer.addEventListener("click", function (event) {
     }
   }
 });
+
+document.addEventListener("click", clearQuotationList);
+document.getElementById("ls-corpus").addEventListener("scroll", clearQuotationList);
 
 
   // // Click-Scroll functionality for T Text


### PR DESCRIPTION
Hi folks -- here are some commits to address your immediate hitches:

> there are multiple lines in LS corpus which should scroll to a target match in T-Pane but they are not scrolling to target.

65e2b76876149124eb71e34cd2d103c642e9706d is to addresses the issue.  All I've done is insert the magic asterisk `*` 🙂

> There’s also the issue that some of the highlighted lines in LS are densely highlighted i.e., there are multiple UIDs that correspond with the line...

32f3bac9bd55e8dd0cd7c776e960299b920cf97d addresses this by having the left-click action popup a menu with relevant UIDs.  The UIDs are clickable and will scroll to the appropriate part in T (using your original code).  I made this a left-click action, as this comports better with the single left-click action for the straightforward case.  I felt the right-click interaction here was a little unexpected, so I removed it (in 12b5970f613495b16acf161996a6a8dc78611991) in favour of this 🙂 -- feel free to do it whatever way you like best, of course.
